### PR TITLE
Note testing uses 'notes' package rather than 'note'

### DIFF
--- a/server/src/test/java/umm3601/notes/NoteControllerSpec.java
+++ b/server/src/test/java/umm3601/notes/NoteControllerSpec.java
@@ -1,4 +1,4 @@
-package umm3601.note;
+package umm3601.notes;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
By putting testing and functionality into the same package, private or internal fields can be effectively tested.