### PR TITLE
Fix the infinite-login-redirect-loop

### DIFF
--- a/client/src/app/add/add-note.component.ts
+++ b/client/src/app/add/add-note.component.ts
@@ -52,7 +52,7 @@ export class AddNoteComponent implements OnInit {
 
 
   retrieveOwner(): void {
-    this.getx500Sub = this.auth.userProfile$.subscribe(returned => {
+    this.getx500Sub = this.auth.getUser$().subscribe(returned => {
       this.x500 = returned.nickname;
     });
     this.getOwnerSub = this.ownerService.getOwnerByx500(this.x500).subscribe(returnedOwner => {

--- a/client/src/app/authentication/auth.guard.ts
+++ b/client/src/app/authentication/auth.guard.ts
@@ -23,7 +23,7 @@ export class AuthGuard implements CanActivate {
           () => result.loggedIn,
           of(true),
           this.authService.login(state.url).pipe(map(() => false)),
-        ),
+        )
       ),
     );
   }

--- a/client/src/app/authentication/auth.guard.ts
+++ b/client/src/app/authentication/auth.guard.ts
@@ -1,27 +1,30 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, CanActivate } from '@angular/router';
-import { Observable } from 'rxjs';
+import { ActivatedRouteSnapshot, RouterStateSnapshot, CanActivate } from '@angular/router';
+import { Observable, iif, of } from 'rxjs';
 import { AuthService } from './auth.service';
-import { tap } from 'rxjs/operators';
+import { concatMap, map } from 'rxjs/operators';
 
+// Based on https://community.auth0.com/t/angular-8-isauthenticated-race-condition/37474/3
 @Injectable({
   providedIn: 'root'
 })
 export class AuthGuard implements CanActivate {
 
-  constructor(private auth: AuthService) {}
+  constructor(private authService: AuthService) {}
 
   canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot
-  ): Observable<boolean> | Promise<boolean|UrlTree> | boolean {
-    return this.auth.isAuthenticated$.pipe(
-      tap(loggedIn => {
-        if (!loggedIn) {
-          this.auth.login();
-        }
-      })
+  ): Observable<boolean> {
+    return this.authService.isAuthenticated$.pipe(
+      concatMap(() => this.authService.handleAuthCallback()),
+      concatMap(result =>
+        iif(
+          () => result.loggedIn,
+          of(true),
+          this.authService.login(state.url).pipe(map(() => false)),
+        ),
+      ),
     );
   }
-
 }

--- a/client/src/app/authentication/auth.service.ts
+++ b/client/src/app/authentication/auth.service.ts
@@ -1,138 +1,88 @@
 import { Injectable } from '@angular/core';
 import createAuth0Client from '@auth0/auth0-spa-js';
 import Auth0Client from '@auth0/auth0-spa-js/dist/typings/Auth0Client';
-import { from, of, Observable, BehaviorSubject, combineLatest, throwError } from 'rxjs';
-import { tap, catchError, concatMap, shareReplay } from 'rxjs/operators';
+import { from, of, Observable, throwError, iif } from 'rxjs';
+import { tap, catchError, concatMap, shareReplay, take, map } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { environment } from '../../environments/environment';
 
+// We should really have a better log-out url.
+// But that's a problem for another day.
+export const REDIRECT_URL = environment.BASE_URL;
+export const LOGOUT_URL = environment.BASE_URL;
+
+// Based on https://community.auth0.com/t/angular-8-isauthenticated-race-condition/37474/3
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
-  // Create an observable of Auth0 instance of client
-  auth0Client$ = (from(
-    createAuth0Client({
-      //This is all specific to our Auth0 application
-      domain: environment.AUTH_DOMAIN,
-      client_id: environment.AUTH_CLIENT_ID,
-      redirect_uri: environment.BASE_URL,
-      // redirect_uri: `${window.location.origin}`
-      audience: environment.AUTH_API_DOMAIN
-    })
-  ) as Observable<Auth0Client>).pipe(
-    shareReplay(1), // Every subscription receives the same shared value
-    catchError(err => throwError(err))
-  );
-  // Define observables for SDK methods that return promises by default
-  // For each Auth0 SDK method, first ensure the client instance is ready
-  // concatMap: Using the client instance, call SDK method; SDK returns a promise
-  // from: Convert that resulting promise into an observable
-  isAuthenticated$ = this.auth0Client$.pipe(
-    concatMap((client: Auth0Client) => from(client.isAuthenticated())),
-    tap(res => this.loggedIn = res)
-  );
-  handleRedirectCallback$ = this.auth0Client$.pipe(
-    concatMap((client: Auth0Client) => from(client.handleRedirectCallback()))
-  );
-  // Create subject and public observable of user profile data
-  private userProfileSubject$ = new BehaviorSubject<any>(null);
-  userProfile$ = this.userProfileSubject$.asObservable();
-  // Create a local property for login status
-  loggedIn: boolean = null;
 
-  constructor(private router: Router) {
-    // On initial load, check authentication state with authorization server
-    // Set up local auth streams if user is already authenticated
-    this.localAuthSetup();
-    // Handle redirect from Auth0 login
-    this.handleAuthCallback();
-  }
+  constructor(public router: Router) {}
 
-  // When calling, options can be passed if desired
-  // https://auth0.github.io/auth0-spa-js/classes/auth0client.html#getuser
+  auth0Client$: Observable<Auth0Client> = from(createAuth0Client({
+    domain: environment.AUTH_DOMAIN,
+    client_id: environment.AUTH_CLIENT_ID,
+    redirect_uri: REDIRECT_URL,
+    audience: environment.AUTH_API_DOMAIN
+  })).pipe(shareReplay(1), catchError(err => throwError(err)));
+
+  isAuthenticated$ = this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
+    from(client.isAuthenticated()),
+  ));
+
+  handleRedirectCallback$ = this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
+    from(client.handleRedirectCallback()),
+  ));
+
   getUser$(options?): Observable<any> {
-    return this.auth0Client$.pipe(
-      concatMap((client: Auth0Client) => from(client.getUser(options))),
-      tap(user => this.userProfileSubject$.next(user))
-    );
+    return this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
+      from(client.getUser(options)),
+    ));
   }
 
   getTokenSilently$(options?): Observable<string> {
-    return this.auth0Client$.pipe(
-      concatMap((client: Auth0Client) => from(client.getTokenSilently(options)))
-    );
+    return this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
+      from(client.getTokenSilently(options)),
+    ));
   }
 
-  private localAuthSetup() {
-    // This should only be called on app initialization
-    // Set up local authentication streams
-    const checkAuth$ = this.isAuthenticated$.pipe(
-      concatMap((loggedIn: boolean) => {
-        if (loggedIn) {
-          // If authenticated, get user and set in app
-          // NOTE: you could pass options here if needed
-          return this.getUser$();
-        }
-        // If not authenticated, return stream that emits 'false'
-        return of(loggedIn);
-      })
-    );
-    checkAuth$.subscribe();
-  }
-
-  login(redirectPath: string = '/') {
-    // A desired redirect path can be passed to login method
-    // (e.g., from a route guard)
-    // Ensure Auth0 client instance exists
-    this.auth0Client$.subscribe((client: Auth0Client) => {
-      // Call method to log in
+  login(redirectPath: string = '/home/dashboard'): Observable<void> {
+    return this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
       client.loginWithRedirect({
-        redirect_uri: environment.BASE_URL,
-        // redirect_uri: `${window.location.origin}`,
-        appState: { target: redirectPath }
-      });
-    });
+        redirect_uri: REDIRECT_URL,
+        appState: { target: redirectPath },
+      }),
+    ));
   }
 
-  private handleAuthCallback() {
-    // Call when app reloads after user logs in with Auth0
-    const params = window.location.search;
-    if (params.includes('code=') && params.includes('state=')) {
-      let targetRoute: string; // Path to redirect to after login processsed
-      const authComplete$ = this.handleRedirectCallback$.pipe(
-        // Have client, now call method to handle auth callback redirect
-        tap(cbRes => {
-          // Get and set target redirect route from callback results
-          targetRoute = cbRes.appState && cbRes.appState.target ? cbRes.appState.target : '/';
-        }),
-        concatMap(() => {
-          // Redirect callback complete; get user and login status
-          return combineLatest([
-            this.getUser$(),
-            this.isAuthenticated$
-          ]);
-        })
-      );
-      // Subscribe to authentication completion observable
-      // Response will be an array of user and login status
-      authComplete$.subscribe(([user, loggedIn]) => {
-        // Redirect to target route after callback processing
-        this.router.navigate([targetRoute]);
-      });
-    }
+  handleAuthCallback(): Observable<{ loggedIn: boolean; targetUrl: string }> {
+    return of(window.location.search).pipe(concatMap(params =>
+      iif(
+        () => params.includes('code=') && params.includes('state='),
+        this.handleRedirectCallback$.pipe(concatMap(redirectResult =>
+          this.isAuthenticated$.pipe(take(1), map(loggedIn => {
+            let targetUrl;
+            if (redirectResult.appState && redirectResult.appState.target) {
+              targetUrl = redirectResult.appState.target;
+            } else {
+              targetUrl = '/';
+            }
+            return { loggedIn, targetUrl };
+          })),
+        )),
+        this.isAuthenticated$.pipe(take(1), map(loggedIn =>
+          ({ loggedIn, targetUrl: null }),
+        )),
+      ),
+    ));
   }
 
   logout() {
-    // Ensure Auth0 client instance exists
-    this.auth0Client$.subscribe((client: Auth0Client) => {
-      // Call method to log out
-      client.logout({
-        client_id: environment.AUTH_CLIENT_ID,
-        returnTo: environment.BASE_URL
-        // returnTo: `${window.location.origin}`
-      });
+   this.auth0Client$.subscribe((client: Auth0Client) => {
+     client.logout({
+       client_id: environment.AUTH_CLIENT_ID,
+       returnTo: LOGOUT_URL,
     });
-  }
-
+  });
+ }
 }

--- a/client/src/app/authentication/auth.service.ts
+++ b/client/src/app/authentication/auth.service.ts
@@ -27,22 +27,22 @@ export class AuthService {
   })).pipe(shareReplay(1), catchError(err => throwError(err)));
 
   isAuthenticated$ = this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
-    from(client.isAuthenticated()),
+    from(client.isAuthenticated())
   ));
 
   handleRedirectCallback$ = this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
-    from(client.handleRedirectCallback()),
+    from(client.handleRedirectCallback())
   ));
 
   getUser$(options?): Observable<any> {
     return this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
-      from(client.getUser(options)),
+      from(client.getUser(options))
     ));
   }
 
   getTokenSilently$(options?): Observable<string> {
     return this.auth0Client$.pipe(concatMap((client: Auth0Client) =>
-      from(client.getTokenSilently(options)),
+      from(client.getTokenSilently(options))
     ));
   }
 
@@ -51,7 +51,7 @@ export class AuthService {
       client.loginWithRedirect({
         redirect_uri: REDIRECT_URL,
         appState: { target: redirectPath },
-      }),
+      })
     ));
   }
 
@@ -68,12 +68,12 @@ export class AuthService {
               targetUrl = '/';
             }
             return { loggedIn, targetUrl };
-          })),
+          }))
         )),
         this.isAuthenticated$.pipe(take(1), map(loggedIn =>
           ({ loggedIn, targetUrl: null }),
         )),
-      ),
+      )
     ));
   }
 

--- a/client/src/app/authentication/interceptor.service.ts
+++ b/client/src/app/authentication/interceptor.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/common/http';
 import { AuthService } from './auth.service';
 import { Observable, throwError } from 'rxjs';
-import { mergeMap, catchError } from 'rxjs/operators';
+import { catchError, concatMap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -20,18 +20,18 @@ export class InterceptorService implements HttpInterceptor {
     req: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
-    if (!this.auth.loggedIn) {
-      return next.handle(req);
-    } else {
+    return this.auth.isAuthenticated$.pipe(concatMap(loggedIn => {
+      if (!loggedIn) {
+        return next.handle(req);
+      }
       return this.auth.getTokenSilently$().pipe(
-        mergeMap(token => {
-          const tokenReq = req.clone({
+        concatMap(token =>
+          next.handle(req.clone({
             setHeaders: { Authorization: `Bearer ${token}` }
-          });
-          return next.handle(tokenReq);
-        }),
+          })),
+        ),
         catchError(err => throwError(err))
       );
-    }
+    }));
   }
 }

--- a/client/src/app/authentication/interceptor.service.ts
+++ b/client/src/app/authentication/interceptor.service.ts
@@ -28,7 +28,7 @@ export class InterceptorService implements HttpInterceptor {
         concatMap(token =>
           next.handle(req.clone({
             setHeaders: { Authorization: `Bearer ${token}` }
-          })),
+          }))
         ),
         catchError(err => throwError(err))
       );

--- a/client/src/app/notes.service.ts
+++ b/client/src/app/notes.service.ts
@@ -4,6 +4,7 @@ import { environment } from '../environments/environment';
 import { Note } from './note';
 import { Observable, throwError, of, OperatorFunction } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
+import { handleHttpError } from './utils';
 
 
 @Injectable({
@@ -56,7 +57,7 @@ export class NotesService {
     // to them.
     return response.pipe(
       map(() => true),
-      this.handleHttpError(404, () => of(false)),
+      handleHttpError(404, () => of(false)),
     );
   }
 
@@ -66,7 +67,7 @@ export class NotesService {
 
     return response.pipe(
       map(() => true),
-      this.handleHttpError(404, () => of(false)),
+      handleHttpError(404, () => of(false)),
     );
   }
 
@@ -76,7 +77,7 @@ export class NotesService {
 
     return response.pipe(
       map(() => true),
-      this.handleHttpError(404, () => of(false)),
+      handleHttpError(404, () => of(false)),
     );
   }
 
@@ -100,23 +101,4 @@ export class NotesService {
   }
   // We could simplify that if statement using a ==, but I've left it
   // in its expanded form for explicitness' sake.
-
-  /**
-   * Return an RxJS operator similar to catchError, except that it only
-   * triggers if the error is an HttpErrorResponse with a given status code.
-   *
-   * (For example, you can use this operator to only handle not-found errors,
-   * while letting other errors pass through.)
-   */
-  private handleHttpError<T, U>(
-    status: number,
-    handler: (err: HttpErrorResponse, caught: Observable<T>) => Observable<U>
-  ): OperatorFunction<T, T | U> {
-    return catchError((error: HttpErrorResponse, caught: Observable<T>) => {
-      if (error.status === status) {
-        return handler(error, caught);
-      }
-      return throwError(error);
-    });
-  }
 }

--- a/client/src/app/owner/owner.component.html
+++ b/client/src/app/owner/owner.component.html
@@ -1,20 +1,20 @@
-<nav class="navbar" *ngIf="owner">
-  <h2>{{this.owner.name}}</h2>
+<nav class="navbar" *ngIf="owner | async">
+  <h2>{{(owner | async)?.name}}</h2>
 </nav>
 
 <div fxLayout="row" id="pdf-div">
   <button mat-button id="generate-pdf-button" type="button" color="primary" (click)="savePDF()">
     GENERATE PDF
   </button>
-  <button mat-button class="logoutButton" type="button" color="primary" (click)="this.auth.logout()"> LOGOUT </button>
+  <button mat-button class="logoutButton" type="button" color="primary" (click)="auth.logout()"> LOGOUT </button>
 </div>
 
 
 
-<div *ngIf="notes; else notesError">
+<div *ngIf="notes | async; else notesError">
 <ul class= "note-container">
-  <mat-card class="note-card" *ngFor="let note of this.notes">
-    <p>{{this.note.body}}</p>
+  <mat-card class="note-card" *ngFor="let note of notes | async">
+    <p>{{note.body}}</p>
     <mat-card-actions>
       <button mat-button class="note-action edit" matTooltip="Edit Note" matTooltipPosition="above" [routerLink]="note._id + '/edit'">
         <mat-icon aria-label="Edit note">create</mat-icon>

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -53,7 +53,6 @@ export class OwnerComponent implements OnInit, AfterViewInit {
     this.owner = this.x500.pipe(
       switchMap(x500 => this.ownerService.getOwnerByx500(x500)),
       handleHttpError(404, () => this.newOwner()),
-      tap({ error(err) { console.log(`Oh no! ${err}`); } }),
       share(),
     );
 

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -33,7 +33,7 @@ export class OwnerComponent implements OnInit, OnDestroy {
 
 
   retrieveOwner(): void {
-    this.getx500Sub = this.auth.userProfile$.subscribe(returned => {
+    this.getx500Sub = this.auth.getUser$().subscribe(returned => {
       this.x500 = returned.nickname;
     });
     this.getOwnerSub = this.ownerService.getOwnerByx500(this.x500).subscribe(returnedOwner => {
@@ -91,7 +91,7 @@ export class OwnerComponent implements OnInit, OnDestroy {
   addOwner(): void {
     let newOwner: Owner;
 
-    this.getx500Sub = this.auth.userProfile$.subscribe(returned => {
+    this.getx500Sub = this.auth.getUser$().subscribe(returned => {
       newOwner = {
         x500: this.x500,
         email: returned.email,

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -83,7 +83,6 @@ export class OwnerComponent implements OnInit, AfterViewInit {
       })),
       flatMap(newOwner =>
         this.ownerService.addOwner(newOwner).pipe(
-          share(),
           map(newId => ({ ...newOwner, _id: newId })),
           tap({
             next: () => this.newUserSucceededSnackBar(),

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -1,15 +1,14 @@
-import { Component, OnInit, OnDestroy} from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewInit} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Owner } from '../owner';
 import { OwnerService } from '../owner.service';
-import { Subscription, Observable, throwError, concat, OperatorFunction } from 'rxjs';
+import { Observable } from 'rxjs';
 import { NotesService } from '../notes.service';
 import { Note } from '../note';
 import {Location} from '@angular/common';
-import { AuthService } from '../authentication/auth.service';
+import { AuthService, REDIRECT_URL } from '../authentication/auth.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { map, concatMap, switchMap, catchError, tap, take, flatMap } from 'rxjs/operators';
-import { HttpErrorResponse } from '@angular/common/http';
 import { handleHttpError } from '../utils';
 
 @Component({
@@ -18,7 +17,7 @@ import { handleHttpError } from '../utils';
   styleUrls: ['./owner.component.scss']
 })
 // This class has access to the owner of the doorboard, and all the posts that said owner has made
-export class OwnerComponent implements OnInit {
+export class OwnerComponent implements OnInit, AfterViewInit {
   constructor(
     private route: ActivatedRoute,
     public auth: AuthService,
@@ -57,6 +56,10 @@ export class OwnerComponent implements OnInit {
     );
 
     this.retrieveNotes();
+  }
+
+  ngAfterViewInit(): void {
+    this._location.replaceState(REDIRECT_URL);
   }
 
   savePDF(): void {

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -35,8 +35,9 @@ export class OwnerComponent implements OnInit, AfterViewInit {
 
   retrieveNotes(): void {
     this.notes = this.owner.pipe(
-      switchMap(owner => this.notesService.getOwnerNotes({owner_id: owner._id, posted: true}).pipe(share())),
+      switchMap(owner => this.notesService.getOwnerNotes({owner_id: owner._id, posted: true})),
       map(notes => notes.reverse()),
+      share(),
     );
   }
 
@@ -50,9 +51,10 @@ export class OwnerComponent implements OnInit, AfterViewInit {
     this.x500 = this.auth.getUser$().pipe(map(returned => returned.nickname));
 
     this.owner = this.x500.pipe(
-      switchMap(x500 => this.ownerService.getOwnerByx500(x500).pipe(share())),
+      switchMap(x500 => this.ownerService.getOwnerByx500(x500)),
       handleHttpError(404, () => this.newOwner()),
       tap({ error(err) { console.log(`Oh no! ${err}`); } }),
+      share(),
     );
 
     this.retrieveNotes();

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -2,12 +2,15 @@ import { Component, OnInit, OnDestroy} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Owner } from '../owner';
 import { OwnerService } from '../owner.service';
-import { Subscription } from 'rxjs';
+import { Subscription, Observable, throwError, concat, OperatorFunction } from 'rxjs';
 import { NotesService } from '../notes.service';
 import { Note } from '../note';
 import {Location} from '@angular/common';
 import { AuthService } from '../authentication/auth.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { map, concatMap, switchMap, catchError, tap, take, flatMap } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+import { handleHttpError } from '../utils';
 
 @Component({
   selector: 'app-owner',
@@ -15,102 +18,85 @@ import { MatSnackBar } from '@angular/material/snack-bar';
   styleUrls: ['./owner.component.scss']
 })
 // This class has access to the owner of the doorboard, and all the posts that said owner has made
-export class OwnerComponent implements OnInit, OnDestroy {
-  constructor(private route: ActivatedRoute, public auth: AuthService,
-              private _location: Location, private notesService: NotesService,
-              private ownerService: OwnerService, private snackBar: MatSnackBar) {
-                console.log("Constructing Owner Component");
-              }
-  notes: Note[];
-  owner: Owner;
-  id: string;
-  name: string;
-  getNotesSub: Subscription;
-  getOwnerSub: Subscription;
-  getx500Sub: Subscription;
-  x500: string;
-  logins: number;
+export class OwnerComponent implements OnInit {
+  constructor(
+    private route: ActivatedRoute,
+    public auth: AuthService,
+    private _location: Location,
+    private notesService: NotesService,
+    private ownerService: OwnerService,
+    private snackBar: MatSnackBar
+  ) {}
 
-
-  retrieveOwner(): void {
-    this.getx500Sub = this.auth.getUser$().subscribe(returned => {
-      this.x500 = returned.nickname;
-    });
-    this.getOwnerSub = this.ownerService.getOwnerByx500(this.x500).subscribe(returnedOwner => {
-      this.owner = returnedOwner;
-      this.retrieveNotes();
-    }, err => {
-      let errorTitle = "The requested owner was not found"
-      if (err.status === 404 && err.error.title === errorTitle) {
-        this.addOwner();
-      }
-      console.log(err);
-    });
-  }
+  notes: Observable<Note[]>;
+  owner: Observable<Owner>;
+  id: Observable<string>;
+  name: Observable<string>;
+  x500: Observable<string>;
 
   retrieveNotes(): void {
-    this.getNotesSub = this.notesService.getOwnerNotes({owner_id: this.owner._id, posted: true}).subscribe(returnedNotes => {
-      this.notes = returnedNotes.reverse();
-    }, err => {
-      console.log(err);
-    });
+    this.notes = this.owner.pipe(
+      switchMap(owner => this.notesService.getOwnerNotes({owner_id: owner._id, posted: true})),
+      map(notes => notes.reverse()),
+    );
   }
 
   deleteNote(id: string): void {
-    this.notesService.deleteNote(id).subscribe(result => {
-      // Ignore the result for now.
+    this.notesService.deleteNote(id).subscribe(() => {
       this.retrieveNotes();
-    }, err => {
-      console.log(err);
     });
   }
 
   ngOnInit(): void {
-    this.retrieveOwner();
-  }
+    this.x500 = this.auth.getUser$().pipe(map(returned => returned.nickname));
 
-  ngOnDestroy(): void {
-    this.unsub();
-  }
+    this.owner = this.x500.pipe(
+      switchMap(x500 => this.ownerService.getOwnerByx500(x500)),
+      handleHttpError(404, () => this.newOwner()),
+      tap({ error(err) { console.log(`Oh no! ${err}`); } }),
+    );
 
-  unsub(): void {
-    if (this.getNotesSub) {
-      this.getNotesSub.unsubscribe();
-    }
-    if (this.getOwnerSub) {
-      this.getOwnerSub.unsubscribe();
-    }
+    this.retrieveNotes();
   }
 
   savePDF(): void {
-
-    // get id of owner, and pass is as a parameter in getPDF
-    this.ownerService.getPDF(this.owner.name, this.x500).save('DoorBoard');
+    this.owner.pipe(take(1)).subscribe(owner => {
+      this.ownerService.getPDF(owner.name, owner.x500).save('DoorBoard.pdf');
+    });
   }
 
-  addOwner(): void {
-    let newOwner: Owner;
-
-    this.getx500Sub = this.auth.getUser$().subscribe(returned => {
-      newOwner = {
-        x500: this.x500,
-        email: returned.email,
-        name: returned.name,
+  newOwner(): Observable<Owner> {
+    return this.auth.getUser$().pipe(
+      take(1),
+      map(user => ({
+        x500: user.nickname,
+        email: user.email,
+        name: user.name,
         _id: null,
         officeNumber: null,
         building: null
-      };
-    });
+      })),
+      flatMap(newOwner =>
+        this.ownerService.addOwner(newOwner).pipe(
+          map(newId => ({ ...newOwner, _id: newId })),
+          tap({
+            next: () => this.newUserSucceededSnackBar(),
+            error: () => this.newUserFailedSnackBar(),
+          }),
+        )
+      ),
+    );
+  }
 
-    this.ownerService.addOwner(newOwner).subscribe(newID => {
-      this.snackBar.open('Successfully created a new owner', null, {
-        duration: 2000,
-      });
-      location.reload();
-    }, err => {
-      this.snackBar.open('Failed to create a new owner', null, {
-        duration: 2000,
-      });
+  newUserSucceededSnackBar() {
+    this.snackBar.open('Successfully created a new owner', null, {
+      duration: 2000,
+    });
+  }
+
+  newUserFailedSnackBar() {
+    this.snackBar.open('Failed to create a new owner', null, {
+      duration: 2000,
     });
   }
 }

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -8,7 +8,7 @@ import { Note } from '../note';
 import {Location} from '@angular/common';
 import { AuthService, REDIRECT_URL } from '../authentication/auth.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { map, concatMap, switchMap, catchError, tap, take, flatMap } from 'rxjs/operators';
+import { map, concatMap, switchMap, catchError, tap, take, flatMap, share } from 'rxjs/operators';
 import { handleHttpError } from '../utils';
 
 @Component({
@@ -35,7 +35,7 @@ export class OwnerComponent implements OnInit, AfterViewInit {
 
   retrieveNotes(): void {
     this.notes = this.owner.pipe(
-      switchMap(owner => this.notesService.getOwnerNotes({owner_id: owner._id, posted: true})),
+      switchMap(owner => this.notesService.getOwnerNotes({owner_id: owner._id, posted: true}).pipe(share())),
       map(notes => notes.reverse()),
     );
   }
@@ -50,7 +50,7 @@ export class OwnerComponent implements OnInit, AfterViewInit {
     this.x500 = this.auth.getUser$().pipe(map(returned => returned.nickname));
 
     this.owner = this.x500.pipe(
-      switchMap(x500 => this.ownerService.getOwnerByx500(x500)),
+      switchMap(x500 => this.ownerService.getOwnerByx500(x500).pipe(share())),
       handleHttpError(404, () => this.newOwner()),
       tap({ error(err) { console.log(`Oh no! ${err}`); } }),
     );
@@ -81,6 +81,7 @@ export class OwnerComponent implements OnInit, AfterViewInit {
       })),
       flatMap(newOwner =>
         this.ownerService.addOwner(newOwner).pipe(
+          share(),
           map(newId => ({ ...newOwner, _id: newId })),
           tap({
             next: () => this.newUserSucceededSnackBar(),

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -59,7 +59,7 @@ export class OwnerComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this._location.replaceState(REDIRECT_URL);
+    this._location.replaceState(new URL(REDIRECT_URL).pathname);
   }
 
   savePDF(): void {

--- a/client/src/app/trash/trash.component.ts
+++ b/client/src/app/trash/trash.component.ts
@@ -59,7 +59,7 @@ export class TrashComponent implements OnInit, OnDestroy  {
   }
 
   retrieveOwner(): void {
-    this.getx500Sub = this.auth.userProfile$.subscribe(returned => {
+    this.getx500Sub = this.auth.getUser$().subscribe(returned => {
       this.x500 = returned.nickname;
     });
     console.log(this.x500);

--- a/client/src/app/utils.ts
+++ b/client/src/app/utils.ts
@@ -1,0 +1,22 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { OperatorFunction, Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+/**
+ * Return an RxJS operator similar to catchError, except that it only
+ * triggers if the error is an HttpErrorResponse with a given status code.
+ *
+ * (For example, you can use this operator to only handle not-found errors,
+ * while letting other errors pass through.)
+ */
+export function handleHttpError<T, U>(
+  status: number,
+  handler: (err: HttpErrorResponse, caught: Observable<T>) => Observable<U>
+): OperatorFunction<T, T | U> {
+  return catchError((error: HttpErrorResponse, caught: Observable<T>) => {
+    if (error.status === status) {
+      return handler(error, caught);
+    }
+    return throwError(error);
+  });
+}


### PR DESCRIPTION
So, it turns out Auth0's "Angular Quick Start" tutorial code has a few race conditions in it. 🙃

In particular, when you have Auth0 set up so that, upon logging in, it redirects you to a route-guarded page, the route guard may take effect *before logging in has completed.* In that case, route guard will send you back to the login page, but the login page thinks that it's finished, so that it'll send you back to the route guard. This cycle will continue until eventually the route guard loses the race.

For more details, see Camden Brown's explanation here: https://community.auth0.com/t/angular-8-isauthenticated-race-condition/37474/3

(Mr. Brown also provides the fix for this issue; we're using his code snippets.)

After that problem is fixed, there's actually another race condition of our own construction. Previously, we had our RxJS subscriptions set up in such a way that sometimes the owner of an OwnerPageComponent gets set to `undefined`.

There's also another race condition where, if you're logging in for the first time, you can start using the website before you get added to the database. (And then you'll be sending requests to the server, but the server won't know who you are.) To fix this issue, the client needs to wait for the `POST /api/owners` response to complete before finishing `ngOnInit()`.

To fix these latter two issues, I've rewritten the observables in `OwnerComponent` to use `.pipe()` and `map()` functions instead of `.subscribe()`.

This does makes the code more complex—it certainly reads less sequentially now. But it would have been a lot harder get it right using just `.subscribe()`! The pipes are harder to read, but they take care of a lot of timing problems for us 🙂

¯\\\_(ツ)\_/¯ It's a trade off.