### PR TITLE
Fix add-note function not working in staging

### DIFF
--- a/client/src/app/add/add-note.component.ts
+++ b/client/src/app/add/add-note.component.ts
@@ -50,9 +50,8 @@ export class AddNoteComponent implements OnInit {
     });
   }
 
-
-  retrieveOwner(): void {
-    this.getx500Sub = this.auth.getUser$().subscribe(returned => {
+  async retrieveOwner(): Promise<void> {
+    this.getx500Sub = await this.auth.getUser$().subscribe(returned  => {
       this.x500 = returned.nickname;
     });
     this.getOwnerSub = this.ownerService.getOwnerByx500(this.x500).subscribe(returnedOwner => {


### PR DESCRIPTION
It turns out that retrieveOwner() in the add-note-component was returning undefined  for the owner because the subscription for the x500 we were grabbing got completed after the program had already called the getOwnerByx500. I've marked the function as async and added an await to the subscription and that seems to have fixed things. 

Closes #32 