### PR TITLE
Change note type and add expiration

### DIFF
--- a/client/src/app/add/add-note.component.ts
+++ b/client/src/app/add/add-note.component.ts
@@ -70,7 +70,7 @@ export class AddNoteComponent implements OnInit {
   submitForm() {
     let newNote: Note = this.addNoteForm.value;
     newNote.owner_id = this.owner._id;
-    newNote.posted = true;
+    newNote.status = 'active';
     this.noteService.addNote(newNote).subscribe(newID => {
       this.snackBar.open('Successfully added note', null, {
         duration: 2000,

--- a/client/src/app/add/add-note.component.ts
+++ b/client/src/app/add/add-note.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { Note } from '../note';
+import { NewNote, Note} from '../note';
 import { Owner } from '../owner';
 import { NotesService } from '../notes.service';
 import { OwnerService } from '../owner.service';
@@ -27,7 +27,7 @@ export class AddNoteComponent implements OnInit {
   x500: string;
 
   constructor(private fb: FormBuilder, private noteService: NotesService, private snackBar: MatSnackBar,
-      private router: Router, private ownerService: OwnerService, private auth: AuthService) {
+              private router: Router, private ownerService: OwnerService, private auth: AuthService) {
   }
 
   addNoteValidationMessages = {
@@ -68,7 +68,7 @@ export class AddNoteComponent implements OnInit {
   }
 
   submitForm() {
-    let newNote: Note = this.addNoteForm.value;
+    const newNote: NewNote = this.addNoteForm.value;
     newNote.owner_id = this.owner._id;
     newNote.status = 'active';
     this.noteService.addNote(newNote).subscribe(newID => {

--- a/client/src/app/note.ts
+++ b/client/src/app/note.ts
@@ -2,5 +2,7 @@ export interface Note {
   _id: string;
   owner_id: string;
   body: string;
-  posted: boolean;
+  addDate: Date;
+  expireDate: Date;
+  status: string;
 }

--- a/client/src/app/note.ts
+++ b/client/src/app/note.ts
@@ -1,8 +1,18 @@
-export interface Note {
+export interface Note extends NewNote {
   _id: string;
-  owner_id: string;
-  body: string;
   addDate: Date;
-  expireDate: Date;
-  status: string;
 }
+
+
+/**
+ * When we create a new note, not all of the fields exist yet. Some of
+ * them are left for the server to fill in.
+ */
+export interface NewNote {
+  body: string;
+  expireDate: Date;
+  status: NoteStatus;
+}
+
+
+export type NoteStatus = 'active' | 'deleted';

--- a/client/src/app/note.ts
+++ b/client/src/app/note.ts
@@ -3,6 +3,6 @@ export interface Note {
   owner_id: string;
   body: string;
   addDate: Date;
-  expireDate: Date;
+  expireDate?: Date;
   status: string;
 }

--- a/client/src/app/notes.service.spec.ts
+++ b/client/src/app/notes.service.spec.ts
@@ -13,7 +13,7 @@ describe('Note service:', () => {
       owner_id: yogiId,
       body: 'You can observe a lot by watching.',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'active',
     },
     {
@@ -21,7 +21,7 @@ describe('Note service:', () => {
       owner_id: yogiId,
       body: 'Nobody goes there anymore. It\'s too crowded.',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'active',
     },
   ];
@@ -32,7 +32,7 @@ describe('Note service:', () => {
       owner_id: 'rachel_id',
       body: 'This is the first note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'active',
     },
     {
@@ -40,7 +40,7 @@ describe('Note service:', () => {
       owner_id: 'joe_id',
       body: 'This is the second note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'active',
     },
     {
@@ -48,7 +48,7 @@ describe('Note service:', () => {
       owner_id: 'james_id',
       body: 'This is the third note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'active',
     },
     ...yogiNotes,

--- a/client/src/app/notes.service.spec.ts
+++ b/client/src/app/notes.service.spec.ts
@@ -7,7 +7,7 @@ import { NotesService } from './notes.service';
 describe('Note service:', () => {
 
   const yogiId = 'yogi_id';
-  const yogiNotes = [
+  const yogiNotes: Note[] = [
     {
       _id: 'y1',
       owner_id: yogiId,

--- a/client/src/app/notes.service.spec.ts
+++ b/client/src/app/notes.service.spec.ts
@@ -12,13 +12,17 @@ describe('Note service:', () => {
       _id: 'y1',
       owner_id: yogiId,
       body: 'You can observe a lot by watching.',
-      posted: true,
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active',
     },
     {
       _id: 'y2',
       owner_id: yogiId,
       body: 'Nobody goes there anymore. It\'s too crowded.',
-      posted: true,
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active',
     },
   ];
 
@@ -27,19 +31,25 @@ describe('Note service:', () => {
       _id: 'first_id',
       owner_id: 'rachel_id',
       body: 'This is the first note',
-      posted: true,
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active',
     },
     {
       _id: 'second_id',
       owner_id: 'joe_id',
       body: 'This is the second note',
-      posted: true,
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active',
     },
     {
       _id: 'third_id',
       owner_id: 'james_id',
       body: 'This is the third note',
-      posted: true,
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active',
     },
     ...yogiNotes,
   ];
@@ -90,14 +100,14 @@ describe('Note service:', () => {
       req.flush(yogiNotes);
     }));
 
-    it('filters by posted status', async(() => {
-      noteService.getOwnerNotes({ posted: false }).subscribe(notes => {
+    it('filters by status', async(() => {
+      noteService.getOwnerNotes({ status: 'deleted' }).subscribe(notes => {
         expect(notes).toEqual([]);
       });
 
       const req = httpTestingController.expectOne({ method: 'GET' });
       expect(req.request.url).toEqual(noteService.noteUrl);
-      expect(req.request.params.get('posted')).toEqual('false');
+      expect(req.request.params.get('status')).toEqual('deleted');
       req.flush([]);
     }));
   });
@@ -288,25 +298,25 @@ describe('Note service:', () => {
   });
 
   describe('The filterNotes() method:', () => {
-    it('can give you a list of all the posted notes', () => {
+    it('can give you a list of all the active notes', () => {
       const filteredNotes =
-        noteService.filterNotes(testNotes, { posted: true });
+        noteService.filterNotes(testNotes, { status: 'active'});
 
-      // All of the testNotes are posted.
+      // All of the testNotes are active.
       expect(filteredNotes).toEqual(testNotes);
     });
 
-    it('can give you a list of all the un-posted notes', () => {
+    it('can give you a list of all the deleted notes', () => {
       const filteredNotes =
-        noteService.filterNotes(testNotes, { posted: false });
+        noteService.filterNotes(testNotes, { status: 'deleted' });
 
-      // None of the testNotes are un-posted.
+      // None of the testNotes are deleted.
       expect(filteredNotes).toEqual([]);
     });
 
     it('doesn\'t break if you give it an empty array of notes', () => {
       const filteredNotes =
-        noteService.filterNotes([], { posted: false });
+        noteService.filterNotes([], { status: 'deleted' });
 
       // None of the testNotes are un-posted.
       expect(filteredNotes).toEqual([]);

--- a/client/src/app/notes.service.ts
+++ b/client/src/app/notes.service.ts
@@ -91,7 +91,7 @@ export class NotesService {
   filterNotes(notes: Note[], filters: {
     status?: string
   }): Note[] {
-    if (filters.status !== null && filters.status !== undefined) {
+    if (filters.status) {
       notes = notes.filter(note => note.status === filters.status);
     }
     return notes;

--- a/client/src/app/notes.service.ts
+++ b/client/src/app/notes.service.ts
@@ -19,17 +19,14 @@ export class NotesService {
 
   constructor(private httpClient: HttpClient) {}
 
-  // getNotes() {
-  //   return this.httpClient.get<Note[]>(this.noteUrl);
-  // }
 
-  getOwnerNotes(filters: { owner_id?: string, posted?: boolean } = {}): Observable<Note[]> {
+  getOwnerNotes(filters: { owner_id?: string, status?: string } = {}): Observable<Note[]> {
     let httpParams: HttpParams = new HttpParams();
     if (filters.owner_id) {
       httpParams = httpParams.set('owner_id', filters.owner_id);
     }
-    if (filters.posted === true || filters.posted === false) {
-      httpParams = httpParams.set('posted', filters.posted.toString());
+    if (filters.status) {
+      httpParams = httpParams.set('status', filters.status);
     }
     return this.httpClient.get<Note[]>(this.noteUrl, {
       params: httpParams,
@@ -92,10 +89,10 @@ export class NotesService {
   }
 
   filterNotes(notes: Note[], filters: {
-    posted?: boolean
+    status?: string
   }): Note[] {
-    if (filters.posted !== null && filters.posted !== undefined) {
-      notes = notes.filter(note => note.posted === filters.posted);
+    if (filters.status !== null && filters.status !== undefined) {
+      notes = notes.filter(note => note.status === filters.status);
     }
     return notes;
   }

--- a/client/src/app/notes.service.ts
+++ b/client/src/app/notes.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams, HttpErrorResponse } from '@angular/common/http';
 import { environment } from '../environments/environment';
-import { Note } from './note';
+import { Note, NewNote } from './note';
 import { Observable, throwError, of, OperatorFunction } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { handleHttpError } from './utils';
@@ -33,7 +33,7 @@ export class NotesService {
     });
   }
 
-  addNote(newNote: Note): Observable<string> {
+  addNote(newNote: NewNote): Observable<string> {
     return this.httpClient.post<{id: string}>(environment.API_URL + 'new/notes', newNote).pipe(map(res => res.id));
   }
 

--- a/client/src/app/owner/owner.component.ts
+++ b/client/src/app/owner/owner.component.ts
@@ -35,7 +35,7 @@ export class OwnerComponent implements OnInit, AfterViewInit {
 
   retrieveNotes(): void {
     this.notes = this.owner.pipe(
-      switchMap(owner => this.notesService.getOwnerNotes({owner_id: owner._id, posted: true})),
+      switchMap(owner => this.notesService.getOwnerNotes({owner_id: owner._id, status: 'active'})),
       map(notes => notes.reverse()),
       share(),
     );

--- a/client/src/app/trash/trash.component.ts
+++ b/client/src/app/trash/trash.component.ts
@@ -72,7 +72,7 @@ export class TrashComponent implements OnInit, OnDestroy  {
   }
 
   retrieveNotes(): void {
-    this.getNotesSub = this.noteService.getOwnerNotes({owner_id: this.owner._id, posted: false}).subscribe(returnedNotes => {
+    this.getNotesSub = this.noteService.getOwnerNotes({owner_id: this.owner._id, status: 'deleted'}).subscribe(returnedNotes => {
       this.notes = returnedNotes.reverse();
     }, err => {
       console.log(err);

--- a/client/src/app/viewer-page/viewer-page.component.ts
+++ b/client/src/app/viewer-page/viewer-page.component.ts
@@ -41,7 +41,7 @@ export class ViewerPageComponent implements OnInit {
   }
 
   retrieveNotes(): void {
-    this.getNotesSub = this.notesService.getOwnerNotes({owner_id: this.owner._id, posted: true}).subscribe(returnedNotes =>{
+    this.getNotesSub = this.notesService.getOwnerNotes({owner_id: this.owner._id, status: 'active'}).subscribe(returnedNotes =>{
       this.notes = returnedNotes.reverse();
     }, err => {
       console.log(err);

--- a/client/src/testing/note.service.mock.ts
+++ b/client/src/testing/note.service.mock.ts
@@ -12,19 +12,25 @@ export class MockNoteService extends NotesService {
       _id: 'first_id',
       owner_id: 'rachel_id',
       body: 'This is the first note',
-      posted: true
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active'
     },
     {
       _id: 'second_id',
       owner_id: 'joe_id',
       body: 'This is the second note',
-      posted: true
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active'
     },
     {
       _id: 'third_id',
       owner_id: 'james_id',
       body: 'This is the third note',
-      posted: true
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active'
     },
 
     // Trashed Notes
@@ -32,25 +38,33 @@ export class MockNoteService extends NotesService {
       _id: 'fourth_id',
       owner_id: 'rachel_id',
       body: 'This is the fourth note',
-      posted: false
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'deleted'
     },
     {
       _id: 'fifth_id',
       owner_id: 'joe_id',
       body: 'This is the fifth note',
-      posted: false
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'deleted'
     },
     {
       _id: 'sixth_id',
       owner_id: 'james_id',
       body: 'This is the 6th note',
-      posted: false
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'deleted'
     },
     {
       _id: 'seventh_id',
       owner_id: 'kyle_id',
       body: 'This is the 7th note',
-      posted: false
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'deleted'
     }
   ];
 
@@ -81,7 +95,9 @@ export class MockNoteService extends NotesService {
       _id: id,
       owner_id: 'rachel_id',
       body: MockNoteService.FAKE_BODY,
-      posted: true,
+      addDate: new Date(),
+      expireDate: new Date(),
+      status: 'active',
     });
   }
 }

--- a/client/src/testing/note.service.mock.ts
+++ b/client/src/testing/note.service.mock.ts
@@ -13,7 +13,7 @@ export class MockNoteService extends NotesService {
       owner_id: 'rachel_id',
       body: 'This is the first note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'active'
     },
     {
@@ -21,7 +21,7 @@ export class MockNoteService extends NotesService {
       owner_id: 'joe_id',
       body: 'This is the second note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'active'
     },
     {
@@ -29,7 +29,7 @@ export class MockNoteService extends NotesService {
       owner_id: 'james_id',
       body: 'This is the third note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'active'
     },
 
@@ -39,7 +39,7 @@ export class MockNoteService extends NotesService {
       owner_id: 'rachel_id',
       body: 'This is the fourth note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'deleted'
     },
     {
@@ -55,7 +55,7 @@ export class MockNoteService extends NotesService {
       owner_id: 'james_id',
       body: 'This is the 6th note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'deleted'
     },
     {
@@ -63,7 +63,7 @@ export class MockNoteService extends NotesService {
       owner_id: 'kyle_id',
       body: 'This is the 7th note',
       addDate: new Date(),
-      expireDate: new Date(),
+      expireDate: null,
       status: 'deleted'
     }
   ];

--- a/server/src/main/java/umm3601/UnprocessableResponse.java
+++ b/server/src/main/java/umm3601/UnprocessableResponse.java
@@ -1,0 +1,28 @@
+package umm3601;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.jetty.http.HttpStatus;
+
+import io.javalin.http.HttpResponseException;
+
+public class UnprocessableResponse extends HttpResponseException {
+
+  public UnprocessableResponse() {
+    super(HttpStatus.UNPROCESSABLE_ENTITY_422, "Unprocessable", Collections.<String, String>emptyMap());
+  }
+
+  public UnprocessableResponse(String msg) {
+    super(HttpStatus.UNPROCESSABLE_ENTITY_422, msg, Collections.<String, String>emptyMap());
+  }
+
+  public UnprocessableResponse(Map<String, String> dt) {
+    super(HttpStatus.UNPROCESSABLE_ENTITY_422, "Unprocessable", dt);
+  }
+
+  public UnprocessableResponse(String msg, Map<String, String> dt) {
+    super(HttpStatus.UNPROCESSABLE_ENTITY_422, msg, dt);
+  }
+
+}

--- a/server/src/main/java/umm3601/notes/DeathTimer.java
+++ b/server/src/main/java/umm3601/notes/DeathTimer.java
@@ -1,0 +1,135 @@
+package umm3601.notes;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import com.fasterxml.jackson.databind.util.StdDateFormat;
+import com.mongodb.client.MongoDatabase;
+
+import umm3601.notes.Note.NoteStatus;
+
+
+
+public class DeathTimer extends Timer {
+
+  public final long ONE_WEEK_MILLIS = 604800000; // 1 week, in milliseconds
+  public final long DELETED_POST_PURGE_DELAY = ONE_WEEK_MILLIS;
+  // In order to make it more obvious what to change, if the customer
+  // wants deleted notes to 'linger' for a different length of time.
+
+  private NoteController noteController;
+
+  private static DeathTimer deathTimerInstance = new DeathTimer();
+
+  protected DeathTimer() {
+    super(true);  // Start as a daemon
+  }
+  // Made not private, with the idea that it'll be injected in actual usage.
+
+  public static DeathTimer getDeathTimerInstance() {
+    return deathTimerInstance;
+  }
+
+  // maps note id to task
+  protected HashMap<String, TimerTask> pendingDeletion = new HashMap<String, TimerTask>();
+
+  DateFormat df = new StdDateFormat();
+
+  /**
+   * Given a single note, correctly sets up timers for its expiration.
+   *
+   * This function behaves slightly differently for different types of note. Any
+   * existing timer will be purged if applicable. Then, notes with an expiration
+   * date (which are understood to be only active dates) will have a timer set
+   * which flags them as deleted at that date, and deleted notes will have a timer
+   * set before they are permanently purged from the database. This timer is
+   * currently set to one week.
+   *
+   * @param n The note whose timer will be updated.
+   * @return true if the note now has a timer attached to it, false otherwise.
+   */
+  public boolean updateTimerStatus(Note n) {
+
+    String noteId = n._id;
+    boolean output = false;
+    TimerTask timerTask;
+    clearKey(noteId);
+
+    if (n.status.equals(NoteStatus.DELETED)) {
+      timerTask = new PurgeTask(noteId);
+      pendingDeletion.put(noteId, timerTask);
+      schedule(timerTask, DELETED_POST_PURGE_DELAY);
+      output = true;
+    } else if (n.status.equals(NoteStatus.ACTIVE) && n.expireDate != null) {
+      timerTask = new ExpireTask(noteId);
+      pendingDeletion.put(noteId, timerTask);
+      schedule(timerTask, n.expireDate);
+      output = true;
+    }
+    return output;
+  }
+
+  public boolean clearKey(String s) {
+    boolean output = false;
+    if (pendingDeletion.containsKey(s)) {
+      output = pendingDeletion.get(s).cancel();
+      pendingDeletion.remove(s);
+    }
+    return output;
+  }
+
+  /**
+   * Completely abandons all pending tasks, cancelling their deletion.
+   *
+   * This should almost certainly not be used in production; it will cancel all
+   * pending deletions with no notification and no indication that the notices in
+   * question will not be deleted or purged.
+   */
+  public void clearAllPending() {
+    pendingDeletion.forEach((String s, TimerTask tt) -> {
+      tt.cancel();
+    });
+    pendingDeletion.clear();
+  }
+
+  public class ExpireTask extends TimerTask {
+
+    String target;
+
+    public ExpireTask(Note n) {
+      target = n._id;
+    }
+
+    public ExpireTask(String noteId) {
+      target = noteId;
+    }
+
+    @Override
+    public void run() {
+      noteController.flagOneForDeletion(target);
+    }
+  }
+
+  public class PurgeTask extends TimerTask {
+
+    String target;
+
+    public PurgeTask(Note n) {
+      target = n._id;
+    }
+
+    public PurgeTask(String noteId) {
+      target = noteId;
+    }
+
+    @Override
+    public void run() {
+      noteController.singleDelete(target);
+    }
+
+  }
+}

--- a/server/src/main/java/umm3601/notes/Note.java
+++ b/server/src/main/java/umm3601/notes/Note.java
@@ -1,14 +1,43 @@
 package umm3601.notes;
 
-import org.mongojack.Id;
-import org.mongojack.ObjectId;
+import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.mongodb.lang.Nullable;
+
+import org.bson.types.ObjectId;
+import org.mongojack.Id;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Note {
 
-  @ObjectId @Id
+  @org.mongojack.ObjectId @Id
   public String _id;
   public String owner_id;
-  public String body;
-  public boolean posted;
 
+  public String body;
+
+  @JsonProperty(value="addDate")
+  public Date getAddDate () {
+    return new ObjectId(_id).getDate();
+  }
+
+  // The annotations appear to contradict here, but they don't.
+  // What they're saying is, "It's totally fine if this property is null,
+  // but if it is we shouldn't serialize it into the document."
+  @Nullable @JsonInclude(Include.NON_NULL)
+  public String expireDate;
+
+  // When serializing or deserializing, this will look like a string.  However,
+  // internally, its values will be constrained.  This makes comparison faster and safer,
+  // but can make using it a little tricky.
+  public enum status {
+    @JsonProperty(value="active") ACTIVE,
+    @JsonProperty(value="draft") DRAFT,
+    @JsonProperty(value="template") TEMPLATE,
+    @JsonProperty(value="deleted") DELETED
+  }
 }

--- a/server/src/main/java/umm3601/notes/Note.java
+++ b/server/src/main/java/umm3601/notes/Note.java
@@ -29,15 +29,16 @@ public class Note {
   // What they're saying is, "It's totally fine if this property is null,
   // but if it is we shouldn't serialize it into the document."
   @Nullable @JsonInclude(Include.NON_NULL)
-  public String expireDate;
+  public Date expireDate;
 
   // When serializing or deserializing, this will look like a string.  However,
   // internally, its values will be constrained.  This makes comparison faster and safer,
   // but can make using it a little tricky.
-  public enum status {
+  public enum NoteStatus {
     @JsonProperty(value="active") ACTIVE,
     @JsonProperty(value="draft") DRAFT,
     @JsonProperty(value="template") TEMPLATE,
     @JsonProperty(value="deleted") DELETED
   }
+  public NoteStatus status;
 }

--- a/server/src/main/java/umm3601/notes/NoteController.java
+++ b/server/src/main/java/umm3601/notes/NoteController.java
@@ -4,6 +4,9 @@ import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 
 import javax.annotation.CheckReturnValue;
@@ -22,10 +25,14 @@ import org.bson.types.ObjectId;
 import org.mongojack.JacksonCodecRegistry;
 
 import io.javalin.http.BadRequestResponse;
+import io.javalin.http.ConflictResponse;
 import io.javalin.http.Context;
+import io.javalin.http.ForbiddenResponse;
 import io.javalin.http.NotFoundResponse;
 import io.javalin.http.UnauthorizedResponse;
 import umm3601.TokenVerifier;
+import umm3601.UnprocessableResponse;
+import umm3601.notes.Note.NoteStatus;
 import umm3601.owners.Owner;
 import umm3601.owners.OwnerController;
 
@@ -37,6 +44,7 @@ public class NoteController {
   private final MongoCollection<Note> noteCollection;
   private final TokenVerifier tokenVerifier;
   private final OwnerController ownerController;
+  private final DeathTimer deathTimer = DeathTimer.getDeathTimerInstance();
 
   public NoteController(MongoDatabase database) {
     jacksonCodecRegistry.addCodecForClass(Note.class);
@@ -110,8 +118,8 @@ public class NoteController {
 
     if (ctx.queryParamMap().containsKey("owner_id")) {
       filters.add(eq("owner_id", ctx.queryParam("owner_id")));
-    if (ctx.queryParamMap().containsKey("posted")) {
-      filters.add(eq("posted", Boolean.parseBoolean(ctx.queryParam("posted"))));
+    if (ctx.queryParamMap().containsKey("status")) {
+      filters.add(eq("status", ctx.queryParam("status")));
     }
     }else{
       throw new NotFoundResponse("The requested owner was not found");
@@ -136,6 +144,9 @@ public class NoteController {
     ctx.json(ImmutableMap.of("id", newNote._id));
   }
 
+  /**
+   * Old version; does not adequately handle updating fields other than the body.
+
   public void editNote(Context ctx) {
     String id = ctx.pathParamMap().get("id");
 
@@ -153,6 +164,109 @@ public class NoteController {
       ctx.json(ImmutableMap.of("id", id));
     }
   }
+  */
+
+  /**
+   * Edit an existing note
+   */
+  public void editNote(Context ctx) {
+
+    Document inputDoc = ctx.bodyAsClass(Document.class); //throws 400 error
+    Document toEdit = new Document();
+    Document toReturn = new Document();
+
+    String id = ctx.pathParam("id");
+    if(inputDoc.isEmpty()) {
+      throw new BadRequestResponse("PATCH request must contain a body.");
+    }
+
+
+    Note note;
+
+    try {
+      note = noteCollection.find(eq("_id", new ObjectId(id))).projection(new Document("addDate", 0)).first();
+      // This really isn't the right way to do things.  Retrieving the database object
+      // in order to check if it exists is inefficient.  We will need to do this at some
+      // point, in order to enforce non-active notices not gaining expiration dates--but
+      // we can probably move that later.  It's a question of: do the expensive thing always;
+      // or do the cheap thing always, and sometimes the expensive thing as well.
+    } catch(IllegalArgumentException e) {
+      throw new BadRequestResponse("The requested note id wasn't a legal Mongo Object ID.");
+    }
+
+    if (note == null) {
+      throw new NotFoundResponse("The requested note does not exist.");
+    }
+
+    // verifyJwtFromHeader will throw an UnauthorizedResponse if the user isn't logged in.
+    // Due to verification in "before" clauses, this isn't necessary.
+    // String currentUserSub = jwtProcessor.verifyJwtFromHeader(ctx).getSubject();
+
+    //String subOfOwnerOfNote = getDoorBoard(note.owner_id).sub;
+
+    /**
+    if (!subOfOwnerOfNote.equals(currentUserSub)) {
+      throw new ForbiddenResponse("Request not allowed; users can only edit their own notes");
+    }
+    */
+
+    HashSet<String> validKeys = new HashSet<String>(Arrays.asList("body", "expireDate", "status"));
+    HashSet<String> forbiddenKeys = new HashSet<String>(Arrays.asList("owner_id", "addDate", "_id"));
+    for (String key: inputDoc.keySet()) {
+      if(forbiddenKeys.contains(key)) {
+        throw new BadRequestResponse("Cannot edit the field " + key + ": this field is not editable and should be considered static.");
+      } else if (!(validKeys.contains(key))){
+        throw new ConflictResponse("Cannot edit the nonexistent field " + key + ".");
+      }
+    }
+
+
+    NoteStatus noteStatus = note.status;
+      // At this point, we're taking information from the user and putting it directly into the database.
+      // I'm unsure of how to properly sanitize this; StackOverflow just says to use PreparedStatements instead
+      // of Statements, but thanks to the magic of mongodb I'm not using either.  At this point I'm going to cross
+      // my fingers really hard and pray that this will be fine.
+
+      if(inputDoc.containsKey("body")) {
+        toEdit.append("body", inputDoc.get("body"));
+      }
+      if (inputDoc.containsKey("status")) {
+        toEdit.append("status", inputDoc.get("status"));
+        noteStatus = NoteStatus.valueOf(inputDoc.get("status").toString().toUpperCase());
+        if(!inputDoc.get("status").equals("active")) {
+          toReturn.append("$unset", new Document("expireDate", ""));
+          //Only active notices can have expiration dates, so if a notice becomes inactive, it loses
+          //its expiration date.
+        }
+      }
+
+      if(inputDoc.containsKey("expireDate")){
+        if(inputDoc.get("expireDate") == null) {
+          toReturn.append("$unset", new Document("expireDate", "")); //If expireDate is specifically included with a null value, remove the expiration date.
+        } else if (!noteStatus.equals("active")) {
+          throw new ConflictResponse("Expiration dates can only be assigned to active notices.");
+          //Order of clauses means we don't mind of someone manually zeroes their expireDate when making something inactive.
+        } else if (new Date().after((Date)inputDoc.get("expireDate"))){
+          throw new UnprocessableResponse("Expiration date cannot be in the past.");
+        } else {
+          toEdit.append("expireDate", inputDoc.get("expireDate"));
+        }
+      }
+
+      //If the message includes a change to status or expiration date, update timers here
+
+      if(!(toEdit.isEmpty())) {
+        toReturn.append("$set", toEdit);
+      }
+      noteCollection.updateOne(eq("_id", new ObjectId(id)), toReturn);
+      //Should probably only run update if expiration date or status changed
+
+      deathTimer.updateTimerStatus(noteCollection.find(eq("_id", new ObjectId(id))).first());
+
+      //we're getting the note, we can(should) send it back with a 201 instead of just a 204
+      //alternatively, give 204 if all the changed fields have the same values and 201 otherwise
+      ctx.status(204);
+    }
 
   /**
    * Move a note with a given id to the trash, if the id exists.
@@ -163,7 +277,7 @@ public class NoteController {
   public void deleteNote(Context ctx) {
     String id = ctx.pathParamMap().get("id");
     // check if owner id of a note, matches logged in user's id
-    Note oldNote = noteCollection.findOneAndUpdate(eq("_id", new ObjectId(id)), set("posted", false));
+    Note oldNote = noteCollection.findOneAndUpdate(eq("_id", new ObjectId(id)), set("status", "deleted"));
 
     if (oldNote == null) {
       throw new NotFoundResponse("The requested note was not found");
@@ -198,4 +312,37 @@ public class NoteController {
       ctx.json(ImmutableMap.of("id", id));
     }
   }
+
+      /**
+     * Silently purge a single notice from the database.
+     *
+     * A helper function which should never be called directly.
+     * This function is not guaranteed to behave well if given an incorrect
+     * or invalid argument.
+     *
+     * @param id the id of the note to be deleted.
+     */
+    protected void singleDelete(String id) {
+      noteCollection.deleteOne(eq("_id", new ObjectId(id)));
+      deathTimer.clearKey(id);
+    }
+
+
+
+    /**
+     * Flags a single notice as deleted.
+     *
+     * A helper function which should never be called directly.
+     * Note that this calls UpdateTimerStatus on said note.
+     * This function is not guaranteed to behave well
+     * if given an incorrect or invalid argument.
+     *
+     * @param id the id of the note to be flagged.
+     */
+    protected void flagOneForDeletion(String id) {
+      noteCollection.updateOne(eq("_id", new ObjectId(id)),
+       new Document("$set", new Document("status", "deleted").append("expireDate", null)));
+      deathTimer.updateTimerStatus(noteCollection.find(eq("_id", new ObjectId(id))).first());
+    }
+
 }

--- a/server/src/main/java/umm3601/notes/NoteController.java
+++ b/server/src/main/java/umm3601/notes/NoteController.java
@@ -140,6 +140,7 @@ public class NoteController {
     .check((note) -> note.body.length() >= 2 && note.body.length() <= 300).get();
 
     noteCollection.insertOne(newNote);
+    deathTimer.updateTimerStatus(newNote);
     ctx.status(201);
     ctx.json(ImmutableMap.of("id", newNote._id));
   }
@@ -243,7 +244,7 @@ public class NoteController {
       if(inputDoc.containsKey("expireDate")){
         if(inputDoc.get("expireDate") == null) {
           toReturn.append("$unset", new Document("expireDate", "")); //If expireDate is specifically included with a null value, remove the expiration date.
-        } else if (!noteStatus.equals("active")) {
+        } else if (!noteStatus.equals(NoteStatus.ACTIVE)) {
           throw new ConflictResponse("Expiration dates can only be assigned to active notices.");
           //Order of clauses means we don't mind of someone manually zeroes their expireDate when making something inactive.
         } else if (new Date().after((Date)inputDoc.get("expireDate"))){

--- a/server/src/test/java/umm3601/notes/NoteControllerSpec.java
+++ b/server/src/test/java/umm3601/notes/NoteControllerSpec.java
@@ -185,7 +185,7 @@ public class NoteControllerSpec {
   @Test
   public void AddNote() throws IOException {
 
-    String testNewNote = "{\"body\": \"Test Note\"}";
+    String testNewNote = "{\"body\": \"Test Note\", \"status\": \"active\"}";
 
     mockReq.setBodyContent(testNewNote);
     mockReq.setMethod("POST");


### PR DESCRIPTION
The note type is substantially changed, most notably moving status to an enum from a boolean (however, it serializes as a string for ease of use) and adding an optional expireDate field and an automatically generated addDate field.  This allows notes to automatically expire at their listed expiration date (issue #11) and displaying the date of creation (issue #8).