### PR TITLE
Display add date

### DIFF
--- a/client/src/app/owner/owner.component.html
+++ b/client/src/app/owner/owner.component.html
@@ -14,7 +14,13 @@
 <div *ngIf="notes | async; else notesError">
 <ul class= "note-container">
   <mat-card class="note-card" *ngFor="let note of notes | async">
-    <p>{{note.body}}</p>
+      <mat-card-content>
+      <p>{{this.note.body}}</p>
+      <div class='addDate'>
+        <p matLine class="note-list-expiration-date">{{note.expireDate}}</p>
+        <p matLine class="note-list-add-date">Created on {{note.addDate | date:'MMM d'}} at {{note.addDate | date:'h:mm aa'}}</p>
+      </div>
+    </mat-card-content>
     <mat-card-actions>
       <button mat-button class="note-action edit" matTooltip="Edit Note" matTooltipPosition="above" [routerLink]="note._id + '/edit'">
         <mat-icon aria-label="Edit note">create</mat-icon>
@@ -23,6 +29,7 @@
         <mat-icon aria-label="Move to trash">delete</mat-icon>
       </button>
     </mat-card-actions>
+
   </mat-card>
 </ul>
 </div>

--- a/client/src/app/owner/owner.component.scss
+++ b/client/src/app/owner/owner.component.scss
@@ -12,6 +12,16 @@
   flex-grow: 1;
 }
 
+.addDate {
+  font-size: smaller;
+  text-align: right;
+  font-weight: lighter;
+}
+
+.addDate .note-list-add-date {
+
+}
+
 .note-card .mat-card-actions {
   display: flex;
   flex-direction: row;

--- a/client/src/app/owner/owner.component.scss
+++ b/client/src/app/owner/owner.component.scss
@@ -18,10 +18,6 @@
   font-weight: lighter;
 }
 
-.addDate .note-list-add-date {
-
-}
-
 .note-card .mat-card-actions {
   display: flex;
   flex-direction: row;

--- a/client/src/app/trash/trash.component.html
+++ b/client/src/app/trash/trash.component.html
@@ -5,7 +5,13 @@
 <div *ngIf="notes; else notesError">
 <ul class= "note-container">
   <mat-card class="note-card" *ngFor="let note of this.notes">
-    <p>{{this.note.body}}</p>
+    <mat-card-content>
+      <p>{{this.note.body}}</p>
+      <div class='addDate'>
+        <p matLine class="note-list-expiration-date">{{note.expireDate}}</p>
+        <p matLine class="note-list-add-date">Created on {{note.addDate | date:'MMM d'}} at {{note.addDate | date:'h:mm aa'}}</p>
+      </div>
+    </mat-card-content>
     <mat-card-actions>
       <button mat-button class="note-action restore" matTooltip="Restore Note" matTooltipPosition="above" (click)="this.restoreNote(note._id);">
         <mat-icon aria-label="Restore note">restore</mat-icon>

--- a/client/src/app/trash/trash.component.scss
+++ b/client/src/app/trash/trash.component.scss
@@ -18,6 +18,12 @@
   justify-content: space-between;
 }
 
+.addDate {
+  font-size: small;
+  text-align: right;
+  font-weight: lighter;
+}
+
 // For some reason, Angular gives margins to every button but the first.
 // So, we have to go back and add these margins manually.
 .note-card .mat-card-actions .mat-button:first-child {

--- a/client/src/app/viewer-page/viewer-page.component.html
+++ b/client/src/app/viewer-page/viewer-page.component.html
@@ -5,7 +5,13 @@
 <div *ngIf="notes; else notesError">
   <ul class= "note-container">
     <mat-card class="note-card" *ngFor="let note of this.notes">
+      <mat-card-content>
       <p>{{this.note.body}}</p>
+      <div class='addDate'>
+        <p matLine class="note-list-expiration-date">{{note.expireDate}}</p>
+        <p matLine class="note-list-add-date">Created on {{note.addDate | date:'MMM d'}} at {{note.addDate | date:'h:mm aa'}}</p>
+      </div>
+    </mat-card-content>
     </mat-card>
   </ul>
 </div>

--- a/client/src/app/viewer-page/viewer-page.component.scss
+++ b/client/src/app/viewer-page/viewer-page.component.scss
@@ -9,3 +9,8 @@ h2 {
   text-decoration: underline;
 }
 
+.addDate {
+  font-size: smaller;
+  text-align: right;
+  font-weight: lighter;
+}


### PR DESCRIPTION
This branch allows viewers and owners to see when they added a note.
I have been trying to move the add date and action buttons to the bottom of note cards, but I was not able to achieve this.