### PR TITLE
Table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This is Team 007's iteration-three code for the DoorBoard web app,
 as part of The UMM CSCI Department's "Software Design and Development" class
 (Spring 2020).
 
+## Table of Contents
+[What is DoorBoard](#what-is-doorboard)
+[Features](#features)
+
  ## What is DoorBoard
 
 DoorBoard is a virtual sticky-note board for office dwellers who need a way to

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# DoorBoard
-
 **Build Status**
 
 [![Server Build Status](../../workflows/Server%20Java/badge.svg)](../../actions?query=workflow%3A"Server+Java")
@@ -10,20 +8,17 @@ This is Team 007's iteration-three code for the DoorBoard web app,
 as part of The UMM CSCI Department's "Software Design and Development" class
 (Spring 2020).
 
-## Table of Contents
-- [DoorBoard](#doorboard)
-  - [Table of Contents](#table-of-contents)
-  - [What is DoorBoard](#what-is-doorboard)
-  - [Features](#features)
-    - [What's on your DoorBoard?](#whats-on-your-doorboard)
-    - [What notes look like](#what-notes-look-like)
-    - [Discarded Notes](#discarded-notes)
-    - [Navigation Menu](#navigation-menu)
-    - [Share Menu (top right in toolbar)](#share-menu-top-right-in-toolbar)
-  - [Known Issues](#known-issues)
-  - [Going Forward](#going-forward)
-  - [Deployment](#deployment)
-  - [Authors](#authors)
+- [What is DoorBoard](#what-is-doorboard)
+- [Features](#features)
+  - [What's on your DoorBoard?](#whats-on-your-doorboard)
+  - [What notes look like](#what-notes-look-like)
+  - [Discarded Notes](#discarded-notes)
+  - [Navigation Menu](#navigation-menu)
+  - [Share Menu (top right in toolbar)](#share-menu-top-right-in-toolbar)
+- [Known Issues](#known-issues)
+- [Going Forward](#going-forward)
+- [Deployment](#deployment)
+- [Authors](#authors)
 
  ## What is DoorBoard
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is Team 007's iteration-three code for the DoorBoard web app,
 as part of The UMM CSCI Department's "Software Design and Development" class
 (Spring 2020).
 
-<!-- TOC depthFrom:1 withLinks:1 -->
+<!-- TOC depthFrom:1 depthTo:5 withLinks:1 updateOnSave:1 orderedList:0 -->
 ## Table of Contents
 [What is DoorBoard](#what-is-doorboard)
 [Features](#features)

--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ This is Team 007's iteration-three code for the DoorBoard web app,
 as part of The UMM CSCI Department's "Software Design and Development" class
 (Spring 2020).
 
-<!-- TOC depthFrom:1 depthTo:5 withLinks:1 updateOnSave:1 orderedList:0 -->
 ## Table of Contents
-[What is DoorBoard](#what-is-doorboard)
-[Features](#features)
-<!-- /TOC -->
+[What is DoorBoard](#what-is-doorboard)  
+[Features](#features)  
+  [What's on your DoorBoard?](#what's-on-your-doorboard?)  
+  [What notes look like](#what-notes-look-like)  
+  [Discarded Notes](#discarded-notes)  
+  [Navigation Menu](#navigation-menu)  
+  [Share Menu (top right in toolbar)](#share-menu-top-right-in-toolbar)  
+[Known Issues](#known-issues)  
+[Going Forward](#going-forward)  
+[Deployment](#deployment)  
+[Authors](#authors)  
+
  ## What is DoorBoard
 
 DoorBoard is a virtual sticky-note board for office dwellers who need a way to
@@ -33,24 +41,24 @@ Doorboard includes:
   - The ability to create a door sign (in the form of a PDF) with the owner's name and link to their page.
   - The ability to copy a link to the viewer page to the clipboard.
 
-## What's on your DoorBoard?
+### What's on your DoorBoard?
 
 Your DoorBoard will display your name and any active notes. 
 
-## What notes look like
+### What notes look like
 
 Notes are created using the add button in the bottom right corner of the website.
 In addition to the text you write, notes display the date and time that they were created.
 They also include an edit button and a trash button;
 clicking the trash button will move a note into the discarded-notes section.
 
-## Discarded Notes
+### Discarded Notes
 
 Once a note has been sent to the trash you can find it by navigating to 
 the discarded-notes page. From here, notes can be permanently deleted.
 They can also be restored to your DoorBoard using the restore button.
 
-## Navigation Menu
+### Navigation Menu
 
 This menu, on the left side of the toolbar, lets you navigate to your DoorBoard or your discarded notes, and it lets you see your DoorBoard in viewer mode. It also contains a logout button. 
 
@@ -58,7 +66,7 @@ Viewer mode brings you to the page that your viewers are able to see.
 When you're still logged in, you will still have the tool bar with the navigation and share menu.
 However, if you aren't logged in, these controls won't be present.
 
-## Share Menu (top right in toolbar)
+### Share Menu (top right in toolbar)
 
 Here is where you can copy a shareable link to your viewer page and generate your personal door sign.
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@ as part of The UMM CSCI Department's "Software Design and Development" class
 (Spring 2020).
 
 ## Table of Contents
-[What is DoorBoard](#what-is-doorboard)  
-[Features](#features)  
-  [What's on your DoorBoard?](#what's-on-your-doorboard?)  
-  [What notes look like](#what-notes-look-like)  
-  [Discarded Notes](#discarded-notes)  
-  [Navigation Menu](#navigation-menu)  
-  [Share Menu (top right in toolbar)](#share-menu-top-right-in-toolbar)  
-[Known Issues](#known-issues)  
-[Going Forward](#going-forward)  
-[Deployment](#deployment)  
-[Authors](#authors)  
+- [DoorBoard](#doorboard)
+  - [Table of Contents](#table-of-contents)
+  - [What is DoorBoard](#what-is-doorboard)
+  - [Features](#features)
+    - [What's on your DoorBoard?](#whats-on-your-doorboard)
+    - [What notes look like](#what-notes-look-like)
+    - [Discarded Notes](#discarded-notes)
+    - [Navigation Menu](#navigation-menu)
+    - [Share Menu (top right in toolbar)](#share-menu-top-right-in-toolbar)
+  - [Known Issues](#known-issues)
+  - [Going Forward](#going-forward)
+  - [Deployment](#deployment)
+  - [Authors](#authors)
 
  ## What is DoorBoard
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ This is Team 007's iteration-three code for the DoorBoard web app,
 as part of The UMM CSCI Department's "Software Design and Development" class
 (Spring 2020).
 
+<!-- TOC depthFrom:1 withLinks:1 -->
 ## Table of Contents
 [What is DoorBoard](#what-is-doorboard)
 [Features](#features)
-
+<!-- /TOC -->
  ## What is DoorBoard
 
 DoorBoard is a virtual sticky-note board for office dwellers who need a way to


### PR DESCRIPTION
This adds a table of contents to our README file that links to the all the different headers we have on there. It also removes the # DoorBoard header, because it kept auto-generating a link there that I thought was superfluous. I think we should instead have the name of the product in the Logo/Pictures, but if that can't happen we can just add the header back and deal with the weird extra link.